### PR TITLE
Fixes issue #6 and adds Pronunciations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *cover.jpg
 *cover.png
 *.opf
-*.csv
+/*.csv
 *.tar.bz2
 *.tmp
 *.zip

--- a/JMdict-frontmatter.html
+++ b/JMdict-frontmatter.html
@@ -23,6 +23,9 @@ Licence Statement, which can found at the WWW site of the
 who are the current owners of the copyright. As explained in the licence, the
 files are distributed under the creative commons licence (CC BY). The files can be used, even commercially, as long as the copyright holder is acknowledged.
 </p>
+<p>
+The files used fro pronunciations are downloaded from <a HREF="https://github.com/javdejong/nhk-pronunciation">javdejong's git repository</a>
+</p>
 <mbp:pagebreak/>
 <h2>LEXICOGRAPHICAL DETAILS</h2>
 

--- a/JMdict_and_JMnedict-Frontmatter.html
+++ b/JMdict_and_JMnedict-Frontmatter.html
@@ -33,6 +33,9 @@ who are the current owners of the copyright. As explained in the licence, the
 files are available for use for most purposes provided acknowledgement
 and distribution of the documentation is made.
 </p>
+<p>
+The files used fro pronunciations are downloaded from <a HREF="https://github.com/javdejong/nhk-pronunciation">javdejong's git repository</a>
+</p>
 <mbp:pagebreak/>
 <h2>LEXICOGRAPHICAL DETAILS</h2>
 

--- a/JMnedict-Frontmatter.html
+++ b/JMnedict-Frontmatter.html
@@ -16,6 +16,9 @@ who are the current owners of the copyright. As explained in the licence, the
 files are available for use for most purposes provided acknowledgement
 and distribution of the documentation is made.
 </p>
+<p>
+The files used fro pronunciations are downloaded from <a HREF="https://github.com/javdejong/nhk-pronunciation">javdejong's git repository</a>
+</p>
 <mbp:pagebreak/>
 <h2>LEXICOGRAPHICAL DETAILS</h2>
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ jmnedict.mobi: JMnedict.xml.gz style.css JMnedict-Frontmatter.html kindlegen
 
 #Currently the limit for sentences is around 30000. After that the file becomes too big	
 combined.mobi: JMdict_e.gz JMnedict.xml.gz sentences.tar.bz2 jpn_indices.tar.bz2 style.css JMdict_and_JMnedict-Frontmatter.html kindlegen
-	$(PYTHON3) jmdict.py -s 0 -d c $(PRONUNCIATIONS_FLAG)
+	$(PYTHON3) jmdict.py -s 0 -d c
 	./$(KINDLEGEN) JMdict_and_JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@	
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -61,18 +61,18 @@ ifeq ($(ONLY_CHECKED_SENTENCES), TRUE)
 else
 	$(PYTHON3) jmdict.py -a -s $(SENTENCES) -d j $(PRONUNCIATIONS_FLAG)
 endif
-
+	./$(KINDLEGEN) JMdict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@
 	
 jmnedict.mobi: JMnedict.xml.gz style.css JMnedict-Frontmatter.html kindlegen
 	$(PYTHON3) jmdict.py -d n
-	
+	./$(KINDLEGEN) JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@
 
 #Currently the limit for sentences is around 30000. After that the file becomes too big	
 combined.mobi: JMdict_e.gz JMnedict.xml.gz sentences.tar.bz2 jpn_indices.tar.bz2 style.css JMdict_and_JMnedict-Frontmatter.html kindlegen
 	$(PYTHON3) jmdict.py -s 0 -d c $(PRONUNCIATIONS_FLAG)
-
+	./$(KINDLEGEN) JMdict_and_JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@	
 
 clean:
 	rm -f *.mobi *.opf entry-*.html *cover.jpg *.tar.bz2 *.gz *.csv *cover.png kindlegen *.tmp *.zip kindlegen.exe	
 	
-.PHONY: all
+.PHONY: all clean

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SENTENCES ?= 5
 # It is ignored bei combined.mobi. there it is always true
 # this is due to size constraints.
 ONLY_CHECKED_SENTENCES ?= FALSE
-
+# If true adds pronunciations indication
 PRONUNCIATIONS ?= TRUE
 
 ifeq ($(PRONUNCIATIONS), TRUE)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPRESSION ?= 1
 # Sets the max sentences per entry only for the jmdict.mobi.
 # It is ignored by combined.mobi due to size restrictions.
 # If there are too many sentences for the combined dictionary,
-# it will not build (exceeds 650MB size limit).
+# it will not build (exceeds 650MB size limit). The amount is limited to three in this makefile
 SENTENCES ?= 5
 # This flag determines wheter only good and verified sentences are used in the
 # dictionary. Set it to TRUE if you only want those sentences.
@@ -69,7 +69,11 @@ jmnedict.mobi: JMnedict.xml.gz style.css JMnedict-Frontmatter.html kindlegen
 
 #Currently the limit for sentences is around 30000. After that the file becomes too big	
 combined.mobi: JMdict_e.gz JMnedict.xml.gz sentences.tar.bz2 jpn_indices.tar.bz2 style.css JMdict_and_JMnedict-Frontmatter.html kindlegen
-	$(PYTHON3) jmdict.py -s 0 -d c
+	ifeq ($(shell test $(VER) -gt 3; echo $$?),0)
+		$(PYTHON3) jmdict.py -s 3 -d c
+	else
+		$(PYTHON3) jmdict.py -s $(SENTENCES) -d c
+	endif
 	./$(KINDLEGEN) JMdict_and_JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@	
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ SENTENCES ?= 5
 # this is due to size constraints.
 ONLY_CHECKED_SENTENCES ?= FALSE
 
+PRONUNCIATIONS ?= TRUE
+
+ifeq ($(PRONUNCIATIONS), TRUE)
+	PRONUNCIATIONS_FLAG ?= -p
+endif
+
 ifeq ($(OS), Windows_NT)
 	PYTHON3 ?= python
 	KINDLEGEN_PKG ?= kindlegen_win32_v2_9.zip
@@ -51,22 +57,22 @@ endif
 # See also https://wiki.mobileread.com/wiki/KindleGen
 jmdict.mobi: JMdict_e.gz sentences.tar.bz2 jpn_indices.tar.bz2 style.css JMdict-frontmatter.html kindlegen
 ifeq ($(ONLY_CHECKED_SENTENCES), TRUE)
-	$(PYTHON3) jmdict.py -s $(SENTENCES) -d j
+	$(PYTHON3) jmdict.py -s $(SENTENCES) -d j $(PRONUNCIATIONS_FLAG)
 else
-	$(PYTHON3) jmdict.py -a -s $(SENTENCES) -d j
+	$(PYTHON3) jmdict.py -a -s $(SENTENCES) -d j $(PRONUNCIATIONS_FLAG)
 endif
-	./$(KINDLEGEN) JMdict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@
+
 	
 jmnedict.mobi: JMnedict.xml.gz style.css JMnedict-Frontmatter.html kindlegen
 	$(PYTHON3) jmdict.py -d n
-	./$(KINDLEGEN) JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@
+	
 
 #Currently the limit for sentences is around 30000. After that the file becomes too big	
 combined.mobi: JMdict_e.gz JMnedict.xml.gz sentences.tar.bz2 jpn_indices.tar.bz2 style.css JMdict_and_JMnedict-Frontmatter.html kindlegen
-	$(PYTHON3) jmdict.py -s 0 -d c
-	./$(KINDLEGEN) JMdict_and_JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@	
+	$(PYTHON3) jmdict.py -s 0 -d c $(PRONUNCIATIONS_FLAG)
+
 
 clean:
 	rm -f *.mobi *.opf entry-*.html *cover.jpg *.tar.bz2 *.gz *.csv *cover.png kindlegen *.tmp *.zip kindlegen.exe	
 	
-.PHONY: all clean
+.PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPRESSION ?= 1
 # Sets the max sentences per entry only for the jmdict.mobi.
 # It is ignored by combined.mobi due to size restrictions.
 # If there are too many sentences for the combined dictionary,
-# it will not build (exceeds 650MB size limit). The amount is limited to three in this makefile
+# it will not build (exceeds 650MB size limit). The amount is limited to 3 in this makefile
 SENTENCES ?= 5
 # This flag determines wheter only good and verified sentences are used in the
 # dictionary. Set it to TRUE if you only want those sentences.
@@ -69,11 +69,11 @@ jmnedict.mobi: JMnedict.xml.gz style.css JMnedict-Frontmatter.html kindlegen
 
 #Currently the limit for sentences is around 30000. After that the file becomes too big	
 combined.mobi: JMdict_e.gz JMnedict.xml.gz sentences.tar.bz2 jpn_indices.tar.bz2 style.css JMdict_and_JMnedict-Frontmatter.html kindlegen
-	ifeq ($(shell test $(VER) -gt 3; echo $$?),0)
-		$(PYTHON3) jmdict.py -s 3 -d c
-	else
-		$(PYTHON3) jmdict.py -s $(SENTENCES) -d c
-	endif
+	if [ $(SENTENCES) -gt 3 ]; then \
+		$(PYTHON3) jmdict.py -s 3 -d c ; \
+	else  \
+		$(PYTHON3) jmdict.py -s $(SENTENCES) -d c ; \
+	fi
 	./$(KINDLEGEN) JMdict_and_JMnedict.opf -c$(COMPRESSION) -verbose -dont_append_source -o $@	
 
 clean:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Features:
 
 * lookup of inflected verbs.
 * lookup for Japanese names.
-* Example sentences
-* Pronunciation
+* Example sentences (not in the combined dictionary due to file size constraints)
+* Pronunciation (not in the combined dictionary due to file size constraints)
 * the dictionaries can be downloaded as separate files or as one big dictionary (the combined dictionary does not include example sentences due to file size restrictions)
 
 <!--

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Features:
 
 * lookup of inflected verbs.
 * lookup for Japanese names.
+* Example sentences
+* Pronunciation
 * the dictionaries can be downloaded as separate files or as one big dictionary (the combined dictionary does not include example sentences due to file size restrictions)
 
 <!--
@@ -113,6 +115,8 @@ SENTENCES ?= 5
 # It is ignored bei combined.mobi. there it is always true
 # this is due to size constraints.
 ONLY_CHECKED_SENTENCES ?= FALSE
+# If true adds pronunciations indication
+PRONUNCIATIONS ?= TRUE
 ```
 
 Build with make to create all 3 dictionaries:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Features:
 * lookup for Japanese names.
 * Example sentences
 * Pronunciation
-* the dictionaries can be downloaded as separate files or as one big dictionary (the combined dictionary does not include example sentences due to file size restrictions)
+* the dictionaries can be downloaded as separate files or as one big dictionary
 
 <!--
 Screenshots were captured inside the Kindle device as explained in
@@ -55,7 +55,7 @@ There are in total 3 dictionaries:
 
 * `jmdict.mobi`: Contains only data from the JMedict database, with additional examples. It does not contain proper names.
 * `jmnedict.mobi`: Contains only Japanese proper names from the JMnedict databse.
-* `combined.mobi`: Contains the data from both of the above dictionaries, but no examples.
+* `combined.mobi`: Contains the data from both of the above dictionaries
 
 To install any of the dictionaries (you can also install all three of them) into your device follow these steps:
 
@@ -107,7 +107,7 @@ COMPRESSION ?= 1
 # Sets the max sentences per entry only for the jmdict.mobi.
 # It is ignored by combined.mobi due to size restrictions.
 # If there are too many sentences for the combined dictionary,
-# it will not build (exceeds 650MB size limit). The amount is limited to 3 for the combined dictionary in this makefile
+# it will not build (exceeds 650MB size limit). The amount is limited to 3 in this makefile
 SENTENCES ?= 5
 # This flag determines wheter only good and verified sentences are used in the
 # dictionary. Set it to TRUE if you only want those sentences.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Features:
 
 * lookup of inflected verbs.
 * lookup for Japanese names.
-* Example sentences (not in the combined dictionary due to file size constraints)
-* Pronunciation (not in the combined dictionary due to file size constraints)
+* Example sentences
+* Pronunciation
 * the dictionaries can be downloaded as separate files or as one big dictionary (the combined dictionary does not include example sentences due to file size restrictions)
 
 <!--
@@ -107,11 +107,11 @@ COMPRESSION ?= 1
 # Sets the max sentences per entry only for the jmdict.mobi.
 # It is ignored by combined.mobi due to size restrictions.
 # If there are too many sentences for the combined dictionary,
-# it will not build (exceeds 650MB size limit).
+# it will not build (exceeds 650MB size limit). The amount is limited to 3 for the combined dictionary in this makefile
 SENTENCES ?= 5
 # This flag determines wheter only good and verified sentences are used in the
 # dictionary. Set it to TRUE if you only want those sentences.
-# It is only used by jmdict.mobi.
+# It is only used by jmdict.mobi
 # It is ignored bei combined.mobi. there it is always true
 # this is due to size constraints.
 ONLY_CHECKED_SENTENCES ?= FALSE
@@ -130,8 +130,6 @@ make jmnedict.mobi
 make combined.mobi
 ```
 
-Please be aware that as of now the combined dictionary does not contain example sentences as this would push the `mobi` beyond the file size limit
-
 To do
 =====
 
@@ -140,7 +138,6 @@ To do
   * cross references
 * Add Furigana to example sentences
 * Create better covers
-* Find a way to have sentences in the combined dictionary (maybe less names). The size limit for `mobi` of 650MB is reached quite fast.
 
 
 Credits

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Credits
 * The [Tatoeba](https://tatoeba.org/) project
 * John Mettraux for his [EDICT2 Japanese-English Kindle dictionary](https://github.com/jmettraux/edict2-kindle)
 * Choplair-network for their [Nihongo conjugator](http://www.choplair.org/?Nihongo%20conjugator)
+* javdejong for the [pronunciation](https://github.com/javdejong/nhk-pronunciation)
 
 
 Alternatives

--- a/dictionary.py
+++ b/dictionary.py
@@ -171,11 +171,30 @@ def write_index(entries, dictionary_name, title, stream):
         stream.write('<idx:entry scriptable="yes">\n')#name attribute is omitted due to size constraints
         
         assert entry.readings
-        label = ';'.join([format_pronunciations(reading) for reading in entry.readings])
+        special_readings = {}
+        readings = []
+        for reading in entry.readings:
+            if reading.re_restr:
+                if(not reading.re_restr in special_readings):
+                    special_readings[reading.re_restr] = []
+                special_readings[reading.re_restr].append(reading)
+            readings.append(format_pronunciations(reading))
+        label = ";".join(readings)
         if entry.kanjis:
             label += '【' + ';'.join([escape(kanji.keb, quote=False) for kanji in entry.kanjis]) + '】'
         
         stream.write(' <p class=lab>' + label + '</p>\n')
+
+        if(len(special_readings.keys()) > 0):
+            for kanji in special_readings:
+                label = ""
+                readings = []
+                for reading in special_readings[kanji]:
+                    readings.append(format_pronunciations(reading))
+                label = ";".join(readings)
+                label += '【' + escape(kanji, quote=False) + '】'
+                stream.write(' <p class=lab>' + label + '</p>\n')
+                    
         assert entry.senses
         
         if(len(entry.senses) > 0):

--- a/dictionary.py
+++ b/dictionary.py
@@ -34,7 +34,7 @@ from cover import *
 from pronunciation import format_pronunciations
 
 NAME_ENTRY, VOCAB_ENTRY = range(2)
-NAME_INDEX, KANJI_INDEX = range(2)
+NAME_INDEX, VOCAB_INDEX = range(2)
 
 Ortho = namedtuple('Ortho', ['value', 'rank','inflgrps'])
 
@@ -142,13 +142,13 @@ def sort_function(entry):
         r_rank = entry.readings[0].rank
     else:
         r_rank = 100
-
+    rank =  min(k_rank, r_rank)
     if(entry.entry_type == VOCAB_ENTRY):
-        return f"1-{r_rank}-{k_rank}-{entry.headword}"
+        return f"1-{rank}-{entry.headword}"
     else:
-        return f"2-{r_rank}-{k_rank}-{entry.headword}"
+        return f"2-{rank}-{entry.headword}"
 
-def write_index(entries, dictionary_name, title, stream, respect_re_restr=True, default_index=KANJI_INDEX):
+def write_index(entries, dictionary_name, title, stream, respect_re_restr=True, default_index=VOCAB_INDEX):
     # http://www.mobipocket.com/dev/article.asp?basefolder=prcgen&file=indexing.htm
     # http://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf
     # http://www.klokan.cz/projects/stardict-lingea/tab2opf.py
@@ -180,7 +180,15 @@ def write_index(entries, dictionary_name, title, stream, respect_re_restr=True, 
             prev_section = section
 
         #scriptable="yes" is needed, otherwise the results are cut off or results after the actual result are also dsiplayed
-        stream.write('<idx:entry scriptable="yes">\n')
+        if  default_index != None:
+            if entry.entry_type == VOCAB_ENTRY:
+                stream.write('<idx:entry name="v" scriptable="yes">\n')
+            elif entry.entry_type == NAME_ENTRY:
+                stream.write('<idx:entry name="n" scriptable="yes">\n')
+            else:
+                print(f"Not implemented entry type: {entry.entry_type}")
+        else:
+            stream.write('<idx:entry scriptable="yes">\n')
         
         assert entry.readings
         if respect_re_restr:
@@ -292,6 +300,10 @@ def write_index(entries, dictionary_name, title, stream, respect_re_restr=True, 
     stream.write('      <output encoding="UTF-8" flatten-dynamic-dir="yes"/>\n')
     stream.write('      <DictionaryInLanguage>ja</DictionaryInLanguage>\n')
     stream.write('      <DictionaryOutLanguage>en</DictionaryOutLanguage>\n')
+    if default_index == VOCAB_INDEX:
+        stream.write('  <DictionaryOutLanguage>v</DictionaryOutLanguage>\n')
+    elif default_index == NAME_INDEX:
+        stream.write('  <DictionaryOutLanguage>n</DictionaryOutLanguage>\n')
     stream.write('    </x-metadata>\n')
     stream.write('  </metadata>\n')
     stream.write('  <manifest>\n')

--- a/dictionary.py
+++ b/dictionary.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*- 
 #
 # Copyright 2014-2017 Jose Fonseca
 # All Rights Reserved.
@@ -30,11 +31,20 @@ from html import escape
 
 from kana import *
 from cover import *
+from pronunciation import format_pronunciations
 
 NAME_ENTRY, VOCAB_ENTRY = range(2)
 
-Ortho = namedtuple('Ortho', ['value', 'rank', 'inflgrps'])
+Ortho = namedtuple('Ortho', ['value', 'rank','inflgrps'])
 
+Kanji = namedtuple('Kanji', ['keb', 'rank'])
+
+class Reading:
+    def __init__(self, reb, rank, re_restr, pronunciation):
+        self.reb = reb
+        self.rank = rank
+        self.re_restr = re_restr
+        self.pronunciation = pronunciation
 
 Sense = namedtuple('Sense', ['pos', 'dial', 'gloss'])
 
@@ -47,10 +57,11 @@ class Sentence:
 
 class Entry:
 
-    def __init__(self, label, senses, orthos, sentences=None, entry_type=VOCAB_ENTRY):
-        self.label = label
+    def __init__(self, senses, orthos, kanjis, readings, sentences=None, entry_type=VOCAB_ENTRY):
         self.senses = senses
         self.orthos = orthos
+        self.kanjis = kanjis
+        self.readings = readings
 
         if(sentences == None):
             self.sentences = []
@@ -153,8 +164,13 @@ def write_index(entries, dictionary_name, title, stream):
 
         #scriptable="yes" is needed, otherwise the results are cut off or results after the actual result are also dsiplayed
         stream.write('<idx:entry scriptable="yes">\n')#name attribute is omitted due to size constraints
-
-        stream.write(' <p class=lab>' + escape(entry.label, quote=False) + '</p>\n')
+        
+        assert entry.readings
+        label = ';'.join([format_pronunciations(reading) for reading in entry.readings])
+        if entry.kanjis:
+            label += '【' + ';'.join([escape(kanji.keb, quote=False) for kanji in entry.kanjis]) + '】'
+        
+        stream.write(' <p class=lab>' + label + '</p>\n')
         assert entry.senses
         
         if(len(entry.senses) > 0):

--- a/dictionary.py
+++ b/dictionary.py
@@ -130,6 +130,11 @@ def write_index_footer(stream):
     stream.write('</body>\n')
     stream.write('</html>\n')
 
+def sort_function(entry):
+    if(entry.entry_type == VOCAB_ENTRY):
+        return f"1-{entry.headword}"
+    else:
+        return f"2-{entry.headword}"
 
 def write_index(entries, dictionary_name, title, stream):
     # http://www.mobipocket.com/dev/article.asp?basefolder=prcgen&file=indexing.htm
@@ -137,7 +142,7 @@ def write_index(entries, dictionary_name, title, stream):
     # http://www.klokan.cz/projects/stardict-lingea/tab2opf.py
 
     # Sort entries alphabetically
-    entries.sort(key=lambda x: x.headword)
+    entries.sort(key=sort_function)
 
     prev_section = None
     dictionary_file_name = dictionary_name.replace(' ', '_')

--- a/jmdict.py
+++ b/jmdict.py
@@ -471,7 +471,7 @@ if(create_jmdict or create_combined):
 
 if(create_jmdict):
     sys.stderr.write('Creating files for JMdict...\n')
-    write_index(jmdict_entries, "JMdict", "JMdict Japanese-English Dictionary", sys.stdout, default_index=KANJI_INDEX)
+    write_index(jmdict_entries, "JMdict", "JMdict Japanese-English Dictionary", sys.stdout, default_index=VOCAB_INDEX)
 
 if(create_jmnedict or create_combined):
     sys.stderr.write('Parsing JMnedict.xml.gz...\n')
@@ -485,4 +485,4 @@ if(create_jmnedict):
 
 if(create_combined):
     sys.stderr.write('Creating files for combined dictionary\n')
-    write_index(jmdict_entries+jmnedict_entries, "JMdict and JMnedict", "Japanese-English Dictionary", sys.stdout, default_index=KANJI_INDEX)
+    write_index(jmdict_entries+jmnedict_entries, "JMdict and JMnedict", "Japanese-English Dictionary", sys.stdout, default_index=None)

--- a/jmdict.py
+++ b/jmdict.py
@@ -456,7 +456,8 @@ if(create_jmdict or create_combined):
     if(pronunciations):
         sys.stderr.write('Adding pronunciations...\n')
         ac = Pronunciation()
-        ac.addPronunciation(jmdict_entries)
+        count = ac.addPronunciation(jmdict_entries)
+        sys.stderr.write(f"added {count} pronunciations\n")
     sys.stderr.write('Created %d entries\n' %len(jmdict_entries))
         
     if(max_sentences > 0):

--- a/jmdict.py
+++ b/jmdict.py
@@ -314,6 +314,7 @@ class JMdictParser(XmlParser):
         posses = []
         dialects = []
         glosses = []
+        misc_info = []
         self.element_start('sense')
         while self.token.type == XML_ELEMENT_START:
             if self.token.name_or_data == 'pos':
@@ -329,11 +330,14 @@ class JMdictParser(XmlParser):
             elif self.token.name_or_data == 'gloss':
                 gloss = self.element_character_data('gloss')
                 glosses.append(gloss)
+            elif self.token.name_or_data == 'misc':
+                misc = self.element_character_data('misc')
+                misc_info.append(misc)
             else:
                 self.skip_element()
         self.element_end('sense')
 
-        sense = Sense(posses, dialects, glosses)
+        sense = Sense(posses, dialects, glosses, misc_info)
         return sense
 
     def element_character_data(self, name):
@@ -400,7 +404,7 @@ class JMnedictParser(JMdictParser):
                 self.skip_element()
         self.element_end('trans')
 
-        sense = Sense(posses, [], glosses)
+        sense = Sense(posses, [], glosses, [])
         return sense
 
 #Get paramters
@@ -467,7 +471,7 @@ if(create_jmdict or create_combined):
 
 if(create_jmdict):
     sys.stderr.write('Creating files for JMdict...\n')
-    write_index(jmdict_entries, "JMdict", "JMdict Japanese-English Dictionary", sys.stdout)
+    write_index(jmdict_entries, "JMdict", "JMdict Japanese-English Dictionary", sys.stdout, default_index=KANJI_INDEX)
 
 if(create_jmnedict or create_combined):
     sys.stderr.write('Parsing JMnedict.xml.gz...\n')
@@ -477,8 +481,8 @@ if(create_jmnedict or create_combined):
 
 if(create_jmnedict):
     sys.stderr.write('Creating files for JMnedict...\n')
-    write_index(jmnedict_entries, "JMnedict", "JMnedict Japanese Names", sys.stdout)
+    write_index(jmnedict_entries, "JMnedict", "JMnedict Japanese Names", sys.stdout, default_index=NAME_INDEX)
 
 if(create_combined):
     sys.stderr.write('Creating files for combined dictionary\n')
-    write_index(jmdict_entries+jmnedict_entries, "JMdict and JMnedict", "Japanese-English Dictionary", sys.stdout)
+    write_index(jmdict_entries+jmnedict_entries, "JMdict and JMnedict", "Japanese-English Dictionary", sys.stdout, default_index=KANJI_INDEX)

--- a/jmdict.py
+++ b/jmdict.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*- 
 #
 # Copyright 2011-2017 Jose Fonseca
 # All Rights Reserved.
@@ -30,6 +31,7 @@ from kana import *
 from dictionary import *
 from inflections import *
 from exampleSentences import *
+from pronunciation import Pronunciation
 
 
 # limit the number of entries for quick experiments
@@ -225,15 +227,18 @@ class JMdictParser(XmlParser):
         kanjis = []
         readings = []
         senses = []
+        orthos = []
 
         self.element_start('entry')
         while self.token.type == XML_ELEMENT_START:
             if self.token.name_or_data == 'k_ele':
                 kanji = self.parse_kanji()
                 kanjis.append(kanji)
+                orthos.append(Ortho(kanji.keb, kanji.rank, {}))
             elif self.token.name_or_data == 'r_ele':
                 reading = self.parse_reading()
                 readings.append(reading)
+                orthos.append(Ortho(reading.reb, reading.rank, {}))
             elif self.token.name_or_data == 'sense':
                 sense = self.parse_sense()
                 senses.append(sense)
@@ -241,21 +246,12 @@ class JMdictParser(XmlParser):
                 self.skip_element()
         self.element_end('entry')
 
-        orthos = kanjis + readings
-
-        # Label
-        assert readings
-        label = ';'.join([reading.value for reading in readings])
-        if kanjis:
-            label += '【' + ';'.join([kanji.value for kanji in kanjis]) + '】'
-
         # Aggregate the POS of all senses
         posses = set()
         for sense in senses:
             for pos in sense.pos:
                 posses.add(pos)
 
-        orthos = readings + kanjis
         for ortho in orthos:
             # Don't try to inflect katakana words
             if not is_katakana(ortho.value):
@@ -268,12 +264,7 @@ class JMdictParser(XmlParser):
                         if infl_dict:
                             ortho.inflgrps[pos] = list(infl_dict.values())
 
-        entry = Entry(label, senses, orthos)
-
-        if 0:
-            print(label)
-            for sense in senses:
-                print('  ' + sense)
+        entry = Entry(senses, orthos, kanjis, readings)
 
         return entry
 
@@ -291,22 +282,26 @@ class JMdictParser(XmlParser):
         self.element_end('k_ele')
 
         assert keb is not None
-        return Ortho(keb, rank, {})
+        return Kanji(keb, rank)
 
     def parse_reading(self):
         reb = None
         rank = 1
+        re_restr = None
+
         self.element_start('r_ele')
         while self.token.type == XML_ELEMENT_START:
             if self.token.name_or_data == 'reb':
                 reb = self.element_character_data('reb')
             elif self.token.name_or_data == 're_pri':
                 rank = min(rank, self.parse_rank())
+            elif self.token.name_or_data == 're_restr':
+                re_restr = self.element_character_data('re_restr')
             else:
                 self.skip_element()
         self.element_end('r_ele')
         assert reb is not None
-        return Ortho(reb, rank, {})
+        return Reading(reb, rank, re_restr, None)
 
     def parse_rank(self):
         re_pri = self.element_character_data('re_pri')
@@ -367,15 +362,18 @@ class JMnedictParser(JMdictParser):
         kanjis = []
         readings = []
         senses = []
+        orthos = []
 
         self.element_start('entry')
         while self.token.type == XML_ELEMENT_START:
             if self.token.name_or_data == 'k_ele':
                 kanji = self.parse_kanji()
                 kanjis.append(kanji)
+                orthos.append(Ortho(kanji.keb, kanji.rank, {}))
             elif self.token.name_or_data == 'r_ele':
                 reading = self.parse_reading()
                 readings.append(reading)
+                orthos.append(Ortho(reading.reb, reading.rank, {}))
             elif self.token.name_or_data == 'trans':
                 sense = self.parse_translation()
                 senses.append(sense)
@@ -383,16 +381,7 @@ class JMnedictParser(JMdictParser):
                 self.skip_element()
         self.element_end('entry')
 
-        orthos = kanjis + readings
-
-        # Label
-        assert readings
-        label = ';'.join([reading.value for reading in readings])
-        if kanjis:
-            label += '【' + ';'.join([kanji.value for kanji in kanjis]) + '】'
-
-        orthos = readings + kanjis
-        return Entry(label, senses, orthos, entry_type=NAME_ENTRY)
+        return Entry(senses, orthos, kanjis, readings, entry_type=NAME_ENTRY)
     
     def parse_translation(self):
         posses = []
@@ -420,6 +409,7 @@ only_good_sentences = True
 create_jmdict = False
 create_jmnedict = False
 create_combined = False
+pronunciations = False
 
 i = 0
 while i < len(sys.argv):
@@ -448,6 +438,10 @@ while i < len(sys.argv):
             elif(c == "c"):
                 create_combined = True
         i += 1
+    # The -p flag enables pronunciations
+    elif(arg == '-p'):
+        pronunciations = True
+        i+=1
 
     i += 1
 
@@ -459,6 +453,10 @@ if(create_jmdict or create_combined):
     sys.stderr.write('Parsing JMdict_e.gz...\n')
     parser = JMdictParser('JMdict_e.gz')
     jmdict_entries = parser.parse()
+    if(pronunciations):
+        sys.stderr.write('Adding pronunciations...\n')
+        ac = Pronunciation()
+        ac.addPronunciation(jmdict_entries)
     sys.stderr.write('Created %d entries\n' %len(jmdict_entries))
         
     if(max_sentences > 0):
@@ -482,4 +480,4 @@ if(create_jmnedict):
 
 if(create_combined):
     sys.stderr.write('Creating files for combined dictionary\n')
-    write_index(jmnedict_entries+jmdict_entries, "JMdict and JMnedict", "Japanese-English Dictionary", sys.stdout)
+    write_index(jmdict_entries+jmnedict_entries, "JMdict and JMnedict", "Japanese-English Dictionary", sys.stdout)

--- a/pronunciation.py
+++ b/pronunciation.py
@@ -1,0 +1,110 @@
+import csv
+from html import escape
+
+hiragana = u'がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ' \
+            u'あいうえおかきくけこさしすせそたちつてと' \
+            u'なにぬねのはひふへほまみむめもやゆよらりるれろ' \
+            u'わをんぁぃぅぇぉゃゅょっ'
+katakana = u'ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ' \
+            u'アイウエオカキクケコサシスセソタチツテト' \
+            u'ナニヌネノハヒフヘホマミムメモヤユヨラリルレロ' \
+            u'ワヲンァィゥェォャュョッ'
+hiragana = [ord(char) for char in hiragana]
+translate_table = dict(zip(hiragana, katakana))
+
+class Pronunciation:
+
+  def __init__(self):
+    self.dict = {}
+    with open("./pronunciation/ACCDB_unicode.csv", encoding="utf-8") as file:
+      csv_reader = csv.DictReader(file, delimiter=',')
+      for row in csv_reader:
+        self.dict[f"{row['kanjiexpr']}-{row['midashigo']}"] = {
+          'nopronouncepos':row['nopronouncepos'],
+          'nasalsoundpos':row['nasalsoundpos'],
+          'ac':row['ac']
+        }
+
+  def addPronunciation(self, entries):
+    for entry in entries:
+      for reading in entry.readings:
+        if reading.re_restr != None:
+          kanji = reading.re_restr
+        elif len(entry.kanjis) > 0:
+          kanji = entry.kanjis[0].keb
+        else:
+          kanji = ""
+          
+        key = f"{kanji}-{reading.reb.translate(translate_table)}"
+        if key in self.dict:
+          reading.pronunciation = self.dict[key]
+        else:
+          reading.pronunciation = None
+
+def format_pronunciations(reading):
+  """ Format an entry from the data in the original database to something that uses html """
+  txt = reading.reb
+  strlen = len(txt)
+  if reading.pronunciation == None:
+    return escape(txt, quote=False)
+  
+  acclen = len(reading.pronunciation['ac'])
+  accent = "0"*(strlen-acclen) + reading.pronunciation['ac']
+
+  # Get the nasal positions
+  nasal = []
+  if reading.pronunciation['nasalsoundpos']:
+      positions = reading.pronunciation['nasalsoundpos'].split('0')
+      for p in positions:
+          if p:
+              nasal.append(int(p))
+          if not p:
+              # e.g. "20" would result in ['2', '']
+              nasal[-1] = nasal[-1] * 10
+
+  # Get the no pronounce positions
+  nopron = []
+  if reading.pronunciation['nopronouncepos']:
+      positions = reading.pronunciation['nopronouncepos'].split('0')
+      for p in positions:
+          if p:
+              nopron.append(int(p))
+          if not p:
+              # e.g. "20" would result in ['2', '']
+              nopron[-1] = nopron[-1] * 10
+
+  outstr = ""
+  overline = False
+
+  for i in range(strlen):
+      a = int(accent[i])
+      # Start or end overline when necessary
+      if not overline and a > 0:
+          outstr = outstr + '<span class="overline">'
+          overline = True
+      if overline and a == 0:
+          outstr = outstr + '</span>'
+          overline = False
+
+      if (i+1) in nopron:
+          outstr = outstr + '<span class="nopron">'
+
+      # Add the character stuff
+      outstr = outstr + escape(txt[i], quote=False)
+
+      # Add the pronunciation stuff
+      if (i+1) in nopron:
+          outstr = outstr + "</span>"
+      if (i+1) in nasal:
+          outstr = outstr + '<span class="nasal">&#176;</span>'
+
+      # If we go down in pitch, add the downfall
+      if a == 2:
+          outstr = outstr + '&#42780;</span>'
+          overline = False
+
+  # Close the overline if it's still open
+  if overline:
+      outstr = outstr + "</span>"
+
+  return outstr

--- a/pronunciation.py
+++ b/pronunciation.py
@@ -12,6 +12,9 @@ katakana = u'ガギグゲゴザジズゼゾダヂヅデドバビブベボパピ�
 hiragana = [ord(char) for char in hiragana]
 translate_table = dict(zip(hiragana, katakana))
 
+HIGH_STATE = 0
+LOW_STATE = 1
+
 class Pronunciation:
 
   def __init__(self):
@@ -74,37 +77,35 @@ def format_pronunciations(reading):
               nopron[-1] = nopron[-1] * 10
 
   outstr = ""
-  overline = False
+  if(int(accent[0]) > 0):
+    state = HIGH_STATE
+    outstr = outstr + '<span class="high">'
+  else:
+    state = LOW_STATE
+    outstr = outstr + '<span class="low">'
+
 
   for i in range(strlen):
-      a = int(accent[i])
-      # Start or end overline when necessary
-      if not overline and a > 0:
-          outstr = outstr + '<span class="overline">'
-          overline = True
-      if overline and a == 0:
-          outstr = outstr + '</span>'
-          overline = False
+    a = int(accent[i])
+    
+    if(state == HIGH_STATE):
+      if a == 0:
+        outstr = outstr + '</span><span class="low">'
+        state = LOW_STATE
+    else:
+      if a > 0:
+        outstr = outstr + '</span><span class="high">'
+        state = HIGH_STATE
 
-      if (i+1) in nopron:
-          outstr = outstr + '<span class="nopron">'
-
-      # Add the character stuff
-      outstr = outstr + escape(txt[i], quote=False)
-
-      # Add the pronunciation stuff
-      if (i+1) in nopron:
-          outstr = outstr + "</span>"
-      if (i+1) in nasal:
-          outstr = outstr + '<span class="nasal">&#176;</span>'
-
-      # If we go down in pitch, add the downfall
-      if a == 2:
-          outstr = outstr + '&#42780;</span>'
-          overline = False
-
-  # Close the overline if it's still open
-  if overline:
-      outstr = outstr + "</span>"
-
+    outstr = outstr + escape(txt[i], quote=False)
+    if (i+1) in nopron:
+      #outstr = outstr + "</span>" dont know what to do here
+      outstr = outstr
+    if (i+1) in nasal:
+      outstr = outstr + '<span class="nasal">&#176;</span>'
+    if a == 2:
+      outstr = outstr + '</span><span class="low">&#42780;'
+      state = LOW_STATE
+    
+  outstr = outstr + '</span>'
   return outstr

--- a/pronunciation.py
+++ b/pronunciation.py
@@ -29,6 +29,7 @@ class Pronunciation:
         }
 
   def addPronunciation(self, entries):
+    count = 0
     for entry in entries:
       for reading in entry.readings:
         if reading.re_restr != None:
@@ -41,8 +42,10 @@ class Pronunciation:
         key = f"{kanji}-{reading.reb.translate(translate_table)}"
         if key in self.dict:
           reading.pronunciation = self.dict[key]
+          count += 1
         else:
           reading.pronunciation = None
+    return count
 
 def format_pronunciations(reading):
   """ Format an entry from the data in the original database to something that uses html """
@@ -79,10 +82,10 @@ def format_pronunciations(reading):
   outstr = ""
   if(int(accent[0]) > 0):
     state = HIGH_STATE
-    outstr = outstr + '<span class="high">'
+    outstr = outstr + '<span class="h">'
   else:
     state = LOW_STATE
-    outstr = outstr + '<span class="low">'
+    outstr = outstr + '<span class="l">'
 
 
   for i in range(strlen):
@@ -90,11 +93,11 @@ def format_pronunciations(reading):
     
     if(state == HIGH_STATE):
       if a == 0:
-        outstr = outstr + '</span><span class="low">'
+        outstr = outstr + '</span><span class="l">'
         state = LOW_STATE
     else:
       if a > 0:
-        outstr = outstr + '</span><span class="high">'
+        outstr = outstr + '</span><span class="h">'
         state = HIGH_STATE
 
     outstr = outstr + escape(txt[i], quote=False)
@@ -102,9 +105,9 @@ def format_pronunciations(reading):
       #outstr = outstr + "</span>" dont know what to do here
       outstr = outstr
     if (i+1) in nasal:
-      outstr = outstr + '<span class="nasal">&#176;</span>'
+      outstr = outstr + '<span class="nas">&#176;</span>'
     if a == 2:
-      outstr = outstr + '</span><span class="low">&#42780;'
+      outstr = outstr + '</span><span class="l">&#42780;'
       state = LOW_STATE
     
   outstr = outstr + '</span>'

--- a/style.css
+++ b/style.css
@@ -1,14 +1,10 @@
 p {
   text-indent: 0;
-  margin-top: 0;
-  margin-left: 0;
-  margin-right: 0;
-  margin-bottom: 0;
+  margin: 0;
 }
 
 .lab {
   font-weight:bold;
-  margin-bottom: 10px;
 }
 
 .pos {

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ li {
 
 .overline{
   text-decoration: overline;
-  font-size: 2rem;
+  font-size: 1.8rem;
 }
 
 .nopron{

--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@ p {
 
 .lab {
   font-weight:bold;
+  margin-bottom: 10px;
 }
 
 .pos {
@@ -33,11 +34,18 @@ li {
   margin-bottom: 8pt;
 }
 
-.overline{
+.high{
   text-decoration: overline;
-  font-size: 1.8rem;
+}
+
+.low{
+  text-decoration: underline;
 }
 
 .nopron{
   color: royalblue;
+}
+
+.nasal{
+  color: limegreen;
 }

--- a/style.css
+++ b/style.css
@@ -32,3 +32,12 @@ li {
   font-weight: bold;
   margin-bottom: 8pt;
 }
+
+.overline{
+  text-decoration: overline;
+  font-size: 2rem;
+}
+
+.nopron{
+  color: royalblue;
+}

--- a/style.css
+++ b/style.css
@@ -34,18 +34,18 @@ li {
   margin-bottom: 8pt;
 }
 
-.high{
+.h{
   text-decoration: overline;
 }
 
-.low{
+.l{
   text-decoration: underline;
 }
 
-.nopron{
+.nop{
   color: royalblue;
 }
 
-.nasal{
+.nas{
   color: limegreen;
 }


### PR DESCRIPTION
This pull request changes the order in which terms are listed in the dictionary (fixes #6 ) and adds pronunciations. The formatting of the pronunciations, as of now is not perfect. Kindle dictionaries appear to not support overlines. That is why different font sizes are used instead.