### PR TITLE
Feature/inflections workaround (#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ PRONUNCIATIONS ?= TRUE
 # If true adds additional information to entries. The combined dictionary ignores this flag due to size constraints
 ADDITIONAL_INFO ?= TRUE
 
+# If true, inflections will be indexed as readings instead of adding then as inflection rules. 
+# This is a workaround for inflected forms to be found in the Android or iOS Kindle Apps, since they do not support inflection rules.
+# It should be false when building for Kindle devices, since inflections are supposed to work fine in this devices.
+INFLECTIONS_AS_READINGS ?= FALSE
+
 ISWSL ?= FALSE
 
 ifeq ($(PRONUNCIATIONS), TRUE)
@@ -29,6 +34,10 @@ endif
 
 ifeq ($(ADDITIONAL_INFO), TRUE)
 	FLAGS += -i
+endif
+
+ifeq ($(INFLECTIONS_AS_READINGS), TRUE)
+	FLAGS += -f
 endif
 
 ifeq ($(OS), Windows_NT)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ well with other _e-ink_ Kindle devices
 
 The dictionary will *not* work well on _Kindle Fire_ or _Kindle Android App_,
 or any Android based Kindle, because the Kindle software on those platforms
-does not support inflection lookups.
+does not support inflection lookups. **Note:** As a workaround, we have added a parameter that allows to build an special version of the dictionary with the inflected forms indexed as alternate readings, they will not work fully as inflections,
+but at least they will be found and the main word should be shown.
 
 
 Download
@@ -42,6 +43,7 @@ Download
 You can download the latest version of the dictionary from
 [here](https://github.com/jrfonseca/jmdict-kindle/releases).
 
+Workaround version for apps or devices not supporting inflections (i.e. Android app): [workaround](https://github.com/xelloss1012/jmdict-kindle/releases/)
 
 Install
 =======
@@ -70,7 +72,7 @@ To install any of the dictionaries (you can also install all three of them) into
 Kindle Android App
 ------------------
 
-**NOTE: Unfortunately the Kindle Android App does not support dictionary inflections, yielding verbs lookup practically impossible. No known workaround.**
+**NOTE: Unfortunately the Kindle Android App does not support dictionary inflections, yielding verbs lookup practically impossible.** As a workaround, we have added a parameter that allows to build an special version of the dictionary whith the inflected forms indexed as alternate readings, they will not work fully as inflections, but at least they will be found and the main word should be shown.
 
 * rename `jmdict.mobi` or any of the other two dictionaries as `B005FNK020_EBOK.prc`
 
@@ -151,6 +153,11 @@ PRONUNCIATIONS ?= TRUE
 
 # If true adds additional information to entries. The combined dictionary ignores this flag due to size constraints
 ADDITIONAL_INFO ?= TRUE
+
+# If true, inflections will be indexed as readings instead of adding then as inflection rules. 
+# This is a workaround for inflected forms to be found in the Android or iOS Kindle Apps, since they do not support inflection rules.
+# It should be false when building for Kindle devices, since inflections are supposed to work fine in this devices.
+INFLECTIONS_AS_READINGS ?= FALSE
 ```
 
 Build with make to create all 3 dictionaries (_Note the combined dictionary will not build with Kindle Previewer due to size constraints_):

--- a/jmdict.py
+++ b/jmdict.py
@@ -280,14 +280,16 @@ class JMdictParser(XmlParser):
                         sys.stderr.write(f"error: {ex.args[0]}\n")
                     else:
                         if infl_dict:
-                            # If the flag inflections_as_readings is True, we add each inflection as a new Ortho. 
+                            # If the flag inflections_as_readings is True, we add each inflection as a new Ortho.
                             # This way they will be indexed as alternate readings and so they will be found in devices that do not support inflections.
                             # otherwise, we assign the inflections to the current ortho
                             if self.inflections_as_readings:
                                 for infl in infl_dict.values():
-                                    orthos_with_inflections.append(Ortho(infl, ortho.rank, {}))                                               
+                                    orthos_with_inflections.append(
+                                        Ortho(infl, ortho.rank, {})
+                                    )
                             else:
-                                ortho.inflgrps[pos] = list(infl_dict.values())                 
+                                ortho.inflgrps[pos] = list(infl_dict.values())
         # Reassing
         orthos = orthos_with_inflections
 
@@ -520,7 +522,9 @@ def main():
         sys.stderr.write("Parsing JMdict_e.gz...\n")
         parser = JMdictParser("JMdict_e.gz")
         if args.inflections_as_readings:
-            sys.stderr.write("Inflections will be added as readings (Android and iOS Kindle apps workaround)...\n")
+            sys.stderr.write(
+                "Inflections will be added as readings (Android and iOS Kindle apps workaround)...\n"
+            )
             parser.inflections_as_readings = args.inflections_as_readings
         jmdict_entries = parser.parse()
         if args.pronunciation:


### PR DESCRIPTION
Add new config parameter INFLECTIONS_AS_READINGS to the makefile that will allow to build a dictionary version with the inflections indexed as readings.

**Note:** This is intended as a workaround for Kindle devices or apps that do not support inflections (jmdict-kindle#15). 