### PR TITLE
No orthos for low pri kanji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ entry-*.html
 kindlegen
 /.vscode
 /out
+__pycache__/

--- a/jmdict.py
+++ b/jmdict.py
@@ -231,8 +231,7 @@ class JMdictParser(XmlParser):
         self.element_start("JMdict")
         while self.token.type == XML_ELEMENT_START:
             entry = self.parse_entry()
-            for kanji in entry.kanjis:
-                entries.append(entry)
+            entries.append(entry)
             if len(entries) >= MAX_ENTRIES:
                 return entries
         self.element_end("JMdict")

--- a/jmdict.py
+++ b/jmdict.py
@@ -379,7 +379,11 @@ class JMdictParser(XmlParser):
                 if not is_kana(ortho[0]) and ortho[1] == 0:
                     common_kanjis.append(ortho[0])
         for entry in entries:
-            entry.orthos = [ortho for ortho in entry.orthos if ortho[1] == 0 or not ortho[0] in common_kanjis]
+            entry.orthos = [
+                ortho
+                for ortho in entry.orthos
+                if ortho[1] == 0 or not ortho[0] in common_kanjis
+            ]
         return entries
 
 

--- a/jmdict.py
+++ b/jmdict.py
@@ -435,16 +435,6 @@ class JMnedictParser(JMdictParser):
         return sense
 
 
-def add_freq_data(jmdict_entries, freq_data):
-    for entry in jmdict_entries:
-        more_common_kanji = ""
-        freq = -1
-        for kanji in entry.kanjis:
-            current_kanji = kanji.keb
-            for reading in entry.readings:
-                pass
-
-
 def get_args():
     class DictAction(argparse.Action):
         def __init__(self, option_strings, dest, nargs=None, **kwargs):

--- a/jmdict.py
+++ b/jmdict.py
@@ -235,6 +235,7 @@ class JMdictParser(XmlParser):
             if len(entries) >= MAX_ENTRIES:
                 return entries
         self.element_end("JMdict")
+        entries = self.remove_orthos_for_uncommon_kanji(entries)
         return entries
 
     def parse_entry(self):
@@ -248,8 +249,7 @@ class JMdictParser(XmlParser):
             if self.token.name_or_data == "k_ele":
                 kanji = self.parse_kanji()
                 kanjis.append(kanji)
-                if kanji.rank == 0:
-                    orthos.append(Ortho(kanji.keb, kanji.rank, {}))
+                orthos.append(Ortho(kanji.keb, kanji.rank, {}))
             elif self.token.name_or_data == "r_ele":
                 reading = self.parse_reading()
                 readings.append(reading)
@@ -371,6 +371,16 @@ class JMdictParser(XmlParser):
         data = self.character_data()
         self.element_end(name)
         return data
+
+    def remove_orthos_for_uncommon_kanji(self, entries):
+        common_kanjis = []
+        for entry in entries:
+            for ortho in entry.orthos:
+                if not is_kana(ortho[0]) and ortho[1] == 0:
+                    common_kanjis.append(ortho[0])
+        for entry in entries:
+            entry.orthos = [ortho for ortho in entry.orthos if ortho[1] == 0 or not ortho[0] in common_kanjis]
+        return entries
 
 
 class JMnedictParser(JMdictParser):


### PR DESCRIPTION
Issue was occurring where less common kanji definitions were appearing for certain words.
e.g. 人間 would be looked up as じんかん (no frequency number from jpdb freq) instead of にんげん (158 freq number from jpdb)

Entries now save value for ke_pri of kanji, if no data of ke_pri for kanji from jmdict, then the dictionary entry does not add that kanji to the orthos list for lookups.